### PR TITLE
Aligned handling of assetId to the way we handle eventIds >> It needs…

### DIFF
--- a/src/routes/assets.js
+++ b/src/routes/assets.js
@@ -47,6 +47,7 @@ const assetRouter = (identityManager, modelEngine, linkHelper) => {
   router.post('/',
     bodyParser.json(),
     presignerMiddleware(identityManager),
+    prehasherMiddleware(identityManager, 'content', 'assetId'),
     asyncMiddleware(createAssetHandler(modelEngine, linkHelper)));
 
   router.get('/:assetId',

--- a/src/services/data_model_engine.js
+++ b/src/services/data_model_engine.js
@@ -21,8 +21,7 @@ export default class DataModelEngine {
   async createAsset(asset) {
     this.entityBuilder.validateAsset(asset);
 
-    let augmentedAsset = this.entityBuilder.regenerateAssetId(asset);
-    augmentedAsset = this.entityBuilder.setAssetBundle(augmentedAsset, null);
+    const augmentedAsset = this.entityBuilder.setAssetBundle(asset, null);
 
     await this.entityRepository.storeAsset(augmentedAsset);
 

--- a/src/services/entity_builder.js
+++ b/src/services/entity_builder.js
@@ -8,6 +8,7 @@ export default class EntityBuilder {
 
   validateAsset(asset) {
     validatePathsNotEmpty(asset, [
+      'assetId',
       'content.idData',
       'content.signature',
       'content.idData.createdBy',
@@ -21,10 +22,6 @@ export default class EntityBuilder {
 
   setAssetBundle(asset, bundle) {
     return put(asset, 'metadata.bundleId', bundle);
-  }
-
-  regenerateAssetId(asset) {
-    return put(asset, 'assetId', this.identityManager.calculateHash(asset.content));
   }
 
   validateEvent(event) {

--- a/test/services/data_model_engine.js
+++ b/test/services/data_model_engine.js
@@ -37,7 +37,6 @@ describe('Data Model Engine', () => {
     mockEntityBuilder = {
       validateAsset: sinon.stub(),
       setAssetBundle: sinon.stub(),
-      regenerateAssetId: sinon.stub(),
       validateEvent: sinon.stub(),
       setEventBundle: sinon.stub()
     };
@@ -66,15 +65,13 @@ describe('Data Model Engine', () => {
   });
 
   describe('creating an asset', () => {
-    it('validates with Entity Builder and sends to Entity Storage', async () => {
-      mockEntityBuilder.regenerateAssetId.returns(mockAsset);
+    it('validates with Entity Builder and sends to Entity Storage', async () => { 
       mockEntityBuilder.setAssetBundle.returns(mockAsset);
       mockEntityRepository.storeAsset.resolves();
 
       await expect(modelEngine.createAsset(mockAsset));
 
       expect(mockEntityBuilder.validateAsset).to.have.been.calledWith(mockAsset);
-      expect(mockEntityBuilder.regenerateAssetId).to.have.been.calledWith(mockAsset);
       expect(mockEntityBuilder.setAssetBundle).to.have.been.calledWith(mockAsset, null);
       expect(mockEntityRepository.storeAsset).to.have.been.calledWith(mockAsset);
     });

--- a/test/services/entity_builder.js
+++ b/test/services/entity_builder.js
@@ -36,7 +36,7 @@ describe('Entity Builder', () => {
   });
 
   describe('validating an asset', () => {
-    for (const field of ['content', 'content.signature', 'content.idData', 'content.idData.createdBy', 'content.idData.timestamp', 'content.idData.sequenceNumber']) {
+    for (const field of ['assetId', 'content', 'content.signature', 'content.idData', 'content.idData.createdBy', 'content.idData.timestamp', 'content.idData.sequenceNumber']) {
       // eslint-disable-next-line no-loop-func
       it(`throws if the ${field} field is missing`, () => {
         const brokenAssset = pick(exampleAsset, field);
@@ -69,15 +69,6 @@ describe('Entity Builder', () => {
   it('setting the bundle Id for an asset', () => {
     const modifiedAsset = entityBuilder.setAssetBundle(exampleAsset, 'abc');
     expect(modifiedAsset.metadata.bundleId).to.equal('abc');
-  });
-
-  it('regenerating assetId', () => {
-    const mockHash = 'xyz';
-    mockIdentityManager.calculateHash.returns(mockHash);
-
-    const regenerated = entityBuilder.regenerateAssetId(exampleAsset);
-    expect(mockIdentityManager.calculateHash).to.have.been.calledWith(exampleAsset.content);
-    expect(regenerated.assetId).to.equal(mockHash);
   });
 
   describe('validating an event', () => {


### PR DESCRIPTION
… to be present, before it arrives at the model engine;