### PR TITLE
Docker: Cache dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,12 @@ FROM node:9
 
 WORKDIR /app
 
-COPY . ./
+COPY ./package.json ./yarn.lock /app/
 
 RUN yarn install
+
+COPY . ./
+
 RUN yarn build
 RUN yarn ops:generate_private_key
 


### PR DESCRIPTION
By copying package.json and yarn.lock before the installation step, the
installation will only be ran if package.json and yarn.lock change. This
should speed up new deployments if there are only code changes as no
dependencies will be installed then.

See: https://stackoverflow.com/a/43190345/2966951