### PR TITLE
Read bundle registry contract address from env

### DIFF
--- a/config/dev.js
+++ b/config/dev.js
@@ -1,9 +1,12 @@
 /* eslint-disable header/header */
+
+const registryContractAddress = (
+  process.env.BUNDLE_REGISTRY_CONTRACT_ADDRESS || require('./registryContractAddress.json')
+);
+
 module.exports = {
   mongoUri: 'mongodb://localhost:27017/ambrosus_gateway_development',
-  bundle: {
-    registryContractAddress: require('./registryContractAddress.json')
-  },
+  bundle: {registryContractAddress},
   web3: {
     rpc: 'http://localhost:8545',
     nodePrivateKey: '0x4d5db4107d237df6a3d58ee5f70ae63d73d7658d4026f2eefd2f204c81682cb7'

--- a/config/production.js
+++ b/config/production.js
@@ -1,8 +1,11 @@
 /* eslint-disable header/header */
+
+const registryContractAddress = (
+  process.env.BUNDLE_REGISTRY_CONTRACT_ADDRESS || require('./registryContractAddress.json')
+);
+
 module.exports = {
-  bundle: {
-    registryContractAddress: require('./registryContractAddress.json')
-  },
+  bundle: {registryContractAddress},
   web3 : {
     nodePrivateKey: require('./nodePrivateKey.json')
   },

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -31,6 +31,9 @@ export default class Config {
     if (this.attributes.bundleRegistryContractAddress) {
       return this.attributes.bundleRegistryContractAddress;
     }
+    if (process.env.BUNDLE_REGISTRY_CONTRACT_ADDRESS) {
+      return process.env.BUNDLE_REGISTRY_CONTRACT_ADDRESS;
+    }
     if (!config.has('bundle.registryContractAddress')) {
       return null;
     }

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -31,9 +31,6 @@ export default class Config {
     if (this.attributes.bundleRegistryContractAddress) {
       return this.attributes.bundleRegistryContractAddress;
     }
-    if (process.env.BUNDLE_REGISTRY_CONTRACT_ADDRESS) {
-      return process.env.BUNDLE_REGISTRY_CONTRACT_ADDRESS;
-    }
     if (!config.has('bundle.registryContractAddress')) {
       return null;
     }


### PR DESCRIPTION
Similar to other config parameters WEB3_NODEPRIVATEKEY, MONGODB_URI,
WEB3_RPC I would like to be able to provide this parameter using the
environment.

The use case is that it simplifies deployments if as much as possible
can be injected using environment variables rather than relying on files
and Docker data volumes.

https://12factor.net/config