### PR TITLE
Add health checks

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -19,7 +19,7 @@ class Application extends Builder {
   }
 
   async startServer() {
-    this.server = new Server(this.dataModelEngine, this.client, this.config);
+    this.server = new Server(this.dataModelEngine, this.config);
     this.server.start();
   }
 

--- a/src/application.js
+++ b/src/application.js
@@ -19,7 +19,7 @@ class Application extends Builder {
   }
 
   async startServer() {
-    this.server = new Server(this.dataModelEngine, this.config);
+    this.server = new Server(this.dataModelEngine, this.client, this.config);
     this.server.start();
   }
 

--- a/src/builder.js
+++ b/src/builder.js
@@ -66,7 +66,9 @@ class Builder {
       this.findEventQueryObjectFactory,
       this.findAccountQueryObjectFactory,
       this.findAssetQueryObjectFactory,
-      this.accountAccessDefinitions);
+      this.accountAccessDefinitions,
+      this.client,
+    );
     return {dataModelEngine: this.dataModelEngine, client: this.client};
   }
 }

--- a/src/routes/health_check.js
+++ b/src/routes/health_check.js
@@ -1,0 +1,32 @@
+/*
+Copyright: Ambrosus Technologies GmbH
+Email: tech@ambrosus.com
+
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+This Source Code Form is “Incompatible With Secondary Licenses”, as defined by the Mozilla Public License, v. 2.0.
+*/
+
+const healthCheckHandler = (mongoClient, web3) => async (req, res) => {
+  if (!mongoClient.isConnected()) {
+    res.status(500)
+      .type('json')
+      .send({msg: 'Is not connected to MongoDB'});
+    return;
+  }
+
+  try {
+    await web3.eth.getNodeInfo();
+  } catch (err) {
+    res.status(500)
+      .type('json')
+      .send({msg: 'Failed to call getNodeInfo'});
+    return;
+  }
+
+  res.status(200)
+    .type('json')
+    .send();
+};
+
+export default healthCheckHandler;

--- a/src/routes/health_check.js
+++ b/src/routes/health_check.js
@@ -8,25 +8,30 @@ This Source Code Form is “Incompatible With Secondary Licenses”, as defined 
 */
 
 const healthCheckHandler = (mongoClient, web3) => async (req, res) => {
+  const status = {
+    mongo: {connected: true},
+    web3: {connected: true}
+  };
+
   if (!mongoClient.isConnected()) {
-    res.status(500)
-      .type('json')
-      .send({msg: 'Is not connected to MongoDB'});
-    return;
+    status.mongo.connected = false;
   }
 
   try {
     await web3.eth.getNodeInfo();
   } catch (err) {
-    res.status(500)
-      .type('json')
-      .send({msg: 'Failed to call getNodeInfo'});
-    return;
+    status.web3.connected = false;
   }
 
-  res.status(200)
-    .type('json')
-    .send();
+  if (!status.mongo.connected || !status.web3.connected) {
+    res.status(500)
+      .type('json')
+      .send(status);
+  } else {
+    res.status(200)
+      .type('json')
+      .send();
+  }
 };
 
 export default healthCheckHandler;

--- a/src/server.js
+++ b/src/server.js
@@ -17,9 +17,11 @@ import bundlesRouter from './routes/bundles';
 import eventsRouter from './routes/events';
 import tokenRouter from './routes/token';
 import nodeInfoRouter from './routes/nodeinfo';
+import healthCheckHandler from './routes/health_check';
 
 export default class Server {
-  constructor(modelEngine, config) {
+  constructor(modelEngine, mongoClient, config) {
+    this.mongoClient = mongoClient;
     this.modelEngine = modelEngine;
     this.config = config;
   }
@@ -40,6 +42,7 @@ export default class Server {
     app.use('/events', eventsRouter(this.modelEngine.tokenAuthenticator, this.modelEngine.identityManager, this.modelEngine));
     app.use('/token', tokenRouter(this.modelEngine.tokenAuthenticator, this.config));
     app.use('/bundle', bundlesRouter(this.modelEngine));
+    app.use('/health_check', healthCheckHandler(this.mongoClient, this.modelEngine.proofRepository.web3));
 
     // Should always be last
     app.use(errorHandling);

--- a/src/server.js
+++ b/src/server.js
@@ -20,8 +20,7 @@ import nodeInfoRouter from './routes/nodeinfo';
 import healthCheckHandler from './routes/health_check';
 
 export default class Server {
-  constructor(modelEngine, mongoClient, config) {
-    this.mongoClient = mongoClient;
+  constructor(modelEngine, config) {
     this.modelEngine = modelEngine;
     this.config = config;
   }
@@ -42,7 +41,7 @@ export default class Server {
     app.use('/events', eventsRouter(this.modelEngine.tokenAuthenticator, this.modelEngine.identityManager, this.modelEngine));
     app.use('/token', tokenRouter(this.modelEngine.tokenAuthenticator, this.config));
     app.use('/bundle', bundlesRouter(this.modelEngine));
-    app.use('/health_check', healthCheckHandler(this.mongoClient, this.modelEngine.proofRepository.web3));
+    app.use('/health', healthCheckHandler(this.modelEngine.mongoClient, this.modelEngine.proofRepository.web3));
 
     // Should always be last
     app.use(errorHandling);

--- a/src/services/data_model_engine.js
+++ b/src/services/data_model_engine.js
@@ -11,7 +11,7 @@ import {NotFoundError, ValidationError, PermissionError} from '../errors/errors'
 import {getTimestamp} from '../utils/time_utils';
 
 export default class DataModelEngine {
-  constructor(identityManager, tokenAuthenticator, entityBuilder, entityRepository, entityDownloader, proofRepository, accountRepository, findEventQueryObjectFactory, findAccountQueryObjectFactory, findAssetQueryObjectFactory, accountAccessDefinitions) {
+  constructor(identityManager, tokenAuthenticator, entityBuilder, entityRepository, entityDownloader, proofRepository, accountRepository, findEventQueryObjectFactory, findAccountQueryObjectFactory, findAssetQueryObjectFactory, accountAccessDefinitions, mongoClient) {
     this.identityManager = identityManager;
     this.tokenAuthenticator = tokenAuthenticator;
     this.entityBuilder = entityBuilder;
@@ -23,6 +23,7 @@ export default class DataModelEngine {
     this.findAccountQueryObjectFactory = findAccountQueryObjectFactory;
     this.findAssetQueryObjectFactory = findAssetQueryObjectFactory;
     this.accountAccessDefinitions = accountAccessDefinitions;
+    this.mongoClient = mongoClient;
   }
 
   async addAdminAccount(address = this.identityManager.nodeAddress()) {


### PR DESCRIPTION
Adds health checks to the application so that we can monitor it's state.
This is important for two reasons:

- On deployment the deployer pings this endpoint to find out if the
  application has booted correctly.

- Once we introduce load balancers the load balancer can detect if the
  application is unhealthy and direct traffic to
  another instance.