### PR TITLE
Eslint: disallow trailing whitespace

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -105,6 +105,7 @@
         "allowTemplateLiterals": true
       }
     ],
+    "no-trailing-spaces": 2,
     "no-console": "off",
     "import/no-unresolved": "error",
     "curly": [

--- a/config/production.js
+++ b/config/production.js
@@ -3,9 +3,9 @@ module.exports = {
   bundle: {
     registryContractAddress: require('./registryContractAddress.json')
   },
-  web3 : { 
+  web3 : {
     nodePrivateKey: require('./nodePrivateKey.json')
   },
-  // note: we have it here for the dev and test networks. Should be removed before deploying the production network 
+  // note: we have it here for the dev and test networks. Should be removed before deploying the production network
   authorizationWithSecretEnabled: true
 };

--- a/src/application.js
+++ b/src/application.js
@@ -13,8 +13,8 @@ import BundleDownloader from './workers/bundle_downloader';
 import BundleFinaliser from './workers/bundle_finaliser';
 
 class Application extends Builder {
-  constructor(output = console) {  
-    super();  
+  constructor(output = console) {
+    super();
     this.output = output;
   }
 
@@ -29,7 +29,7 @@ class Application extends Builder {
     this.bundleFinaliser = new BundleFinaliser(this.dataModelEngine, this.config.bundleFinalisationInterval(),
       this.config.bundleSizeLimit(), this.output);
     this.bundleFinaliser.start();
-  }  
+  }
 }
 
 export default Application;

--- a/src/routes/accounts.js
+++ b/src/routes/accounts.js
@@ -46,7 +46,7 @@ export default (tokenAuthenticator, dataModelEngine) => {
 
   router.post('/',
     ensureJsonMime,
-    bodyParser.json(),  
+    bodyParser.json(),
     accessTokenMiddleware(tokenAuthenticator),
     asyncMiddleware(addAccountHandler(dataModelEngine)));
 
@@ -60,7 +60,7 @@ export default (tokenAuthenticator, dataModelEngine) => {
 
   router.put('/:id',
     ensureJsonMime,
-    bodyParser.json(),  
+    bodyParser.json(),
     accessTokenMiddleware(tokenAuthenticator),
     asyncMiddleware(modifyAccountHandler(dataModelEngine)));
 

--- a/src/routes/assets.js
+++ b/src/routes/assets.js
@@ -37,7 +37,7 @@ export const createEventHandler = (modelEngine) => async (req, res) => {
   if (req.params.assetId !== req.body.content.idData.assetId) {
     throw new ValidationError('The assetId in the path mismatches the one in the event body');
   }
-  
+
   const createdEvent = await modelEngine.createEvent(req.body);
 
   res.status(201)

--- a/src/server.js
+++ b/src/server.js
@@ -43,7 +43,7 @@ export default class Server {
 
     // Should always be last
     app.use(errorHandling);
-    
+
     this.server = app.listen(this.config.serverPort());
   }
 

--- a/src/services/find_asset_query_object.js
+++ b/src/services/find_asset_query_object.js
@@ -32,5 +32,5 @@ export default class FindAssetQueryObjectFactory {
 
   create() {
     return new FindAssetQueryObject(this.db);
-  } 
+  }
 }

--- a/src/services/find_event_query_object.js
+++ b/src/services/find_event_query_object.js
@@ -96,5 +96,5 @@ export default class FindEventQueryObjectFactory {
 
   create(criteria, accessLevel) {
     return new FindEventQueryObject(this.db, criteria, accessLevel);
-  } 
+  }
 }

--- a/src/services/proof_repository.js
+++ b/src/services/proof_repository.js
@@ -16,14 +16,14 @@ export default class ProofRepository {
     this.registryContract = registryContract;
     this.defaultGas = defaultGas;
   }
-  
+
   async getVendorUrl(vendorAddress) {
     const from = getDefaultAddress(this.web3);
     return this.registryContract
       .methods
       .getUrlForVendor(vendorAddress)
       .call({from});
-  }    
+  }
 
   async isWhitelisted(vendorAddress) {
     const from = getDefaultAddress(this.web3);
@@ -31,7 +31,7 @@ export default class ProofRepository {
       .methods
       .isWhitelisted(vendorAddress)
       .call({from});
-  }    
+  }
 
   async addVendor(vendorAddress, url) {
     return this.registryContract

--- a/src/tasks/generate_private_key.js
+++ b/src/tasks/generate_private_key.js
@@ -22,7 +22,7 @@ async function execute() {
 
   const account = web3.eth.accounts.create();
   const {privateKey, address} = account;
-  
+
   await writeFile(keyFilePath, JSON.stringify(privateKey));
   console.log(`Generated address/privateKey pair:\n\taddress: ${address}\n\tprivate key: ${privateKey}\n\nSaving under ${keyFilePath}`);
 }

--- a/src/utils/https_client.js
+++ b/src/utils/https_client.js
@@ -13,9 +13,9 @@ import URL from 'url';
 
 import {NotFoundError, PermissionError, ValidationError, AuthenticationError} from '../errors/errors';
 export default class HttpsClient {
-  async performHTTPSGet(uri, path) {    
+  async performHTTPSGet(uri, path) {
     const {protocol, hostname, port} = URL.parse(uri);
-    const agent = this.getAgentFromProtocol(protocol);        
+    const agent = this.getAgentFromProtocol(protocol);
     const options = {
       hostname,
       path,
@@ -42,8 +42,8 @@ export default class HttpsClient {
       return https;
     } else if (protocol.startsWith('http')) {
       return http;
-    } 
-    throw Error(`Invalid protocol ${protocol}`);       
+    }
+    throw Error(`Invalid protocol ${protocol}`);
   }
 
   validateIncomingStatusCode(statusCode) {

--- a/src/utils/token_authenticator.js
+++ b/src/utils/token_authenticator.js
@@ -50,7 +50,7 @@ export default class TokenAuthenticator {
   preparePayload(secret, idData) {
     const signature = this.identityManager.sign(secret, idData);
     const payload = {signature, idData};
-    return payload;  
+    return payload;
   }
 
   decode(token) {

--- a/src/validators/json_schema_validator.js
+++ b/src/validators/json_schema_validator.js
@@ -21,7 +21,7 @@ export default class JsonSchemaValidator extends Validator {
   isValid(data) {
     return this.ajv.validate(this.schema, data);
   }
-  
+
   validate(data) {
     if (!this.isValid(data)) {
       throw new JsonValidationError(this.ajv.errors);

--- a/src/validators/validator.js
+++ b/src/validators/validator.js
@@ -8,7 +8,7 @@ This Source Code Form is “Incompatible With Secondary Licenses”, as defined 
 */
 
 /* eslint no-unused-vars: ["error", { "argsIgnorePattern": "^_" }]*/
-export default class Validator {  
+export default class Validator {
   validate(_data) {
     throw new Error('Abstract class');
   }

--- a/src/workers/bundle_downloader.js
+++ b/src/workers/bundle_downloader.js
@@ -25,20 +25,20 @@ export default class BundleDownloader extends PeriodicWorker {
     return this.downloadAllNew();
   }
 
-  async downloadAllNew() {    
+  async downloadAllNew() {
     const count = await this.proofRepository.getBundleCount();
     this.output.log(`Found ${count - this.last} new bundles.`);
     for (let index = this.last; index < count; index++) {
       await this.downloadOne(index);
-    }    
+    }
     this.last = count;
   }
 
-  async downloadOne(index) {    
+  async downloadOne(index) {
     const bundleId = await this.proofRepository.getBundleByIndex(index);
     const vendorId = (await this.proofRepository.getNodeForBundle(bundleId)).toLowerCase();
     const vendorUrl = await this.proofRepository.getVendorUrl(vendorId);
-    this.output.log(`Downloading bundle ${bundleId} (index: ${index}) for vendor: ${vendorId} from ${vendorUrl}...`);    
+    this.output.log(`Downloading bundle ${bundleId} (index: ${index}) for vendor: ${vendorId} from ${vendorUrl}...`);
     await this.dataModelEngine.downloadBundle(bundleId, vendorId);
     this.output.log(`Bundle downloaded.`);
   }

--- a/src/workers/periodic_worker.js
+++ b/src/workers/periodic_worker.js
@@ -25,7 +25,7 @@ export default class PeriodicWorker {
   }
 
   async beforeStart() {
-    
+
   }
 
   async work() {

--- a/test/helpers/apparatus.js
+++ b/test/helpers/apparatus.js
@@ -46,7 +46,7 @@ export default class Apparatus extends Application {
   async cleanDB() {
     return cleanDatabase(this.db);
   }
-  
+
   url() {
     return `http://127.0.0.1:${this.config.serverPort()}`;
   }

--- a/test/helpers/events.js
+++ b/test/helpers/events.js
@@ -9,7 +9,7 @@ This Source Code Form is “Incompatible With Secondary Licenses”, as defined 
 
 /* eslint no-underscore-dangle: ["error", { "allow": ["_obj"] }] */
 module.exports = function () {
-  const emitEventMethod = function (eventName) {    
+  const emitEventMethod = function (eventName) {
     const tx = this._obj;
     const eventOccurences = tx.events[eventName];
     this.assert(

--- a/test/helpers/null_console.js
+++ b/test/helpers/null_console.js
@@ -9,8 +9,8 @@ This Source Code Form is “Incompatible With Secondary Licenses”, as defined 
 
 class NullConsole {
   log() {
-    
-  }    
+
+  }
 }
 
 export default new NullConsole();

--- a/test/integration/assets.js
+++ b/test/integration/assets.js
@@ -94,7 +94,7 @@ describe('Assets - Integrations', () => {
 
     it('returns 403 for authorisation error (user does not exist)', async () => {
       const failingAsset = createFullAsset(apparatus.identityManager, {createdBy: notRegisteredAccount.address}, notRegisteredAccount.secret);
-      
+
       const request = apparatus.request()
         .post('/assets')
         .send(failingAsset);

--- a/test/integration/bundles.js
+++ b/test/integration/bundles.js
@@ -25,7 +25,7 @@ chai.use(chaiAsPromised);
 const {expect} = chai;
 
 describe('Bundles - Integrations', () => {
-  const url = 'node.ambrosus.com';  
+  const url = 'node.ambrosus.com';
   let apparatus;
   let scenario;
   let res;
@@ -62,7 +62,7 @@ describe('Bundles - Integrations', () => {
 
     res = await apparatus.dataModelEngine.finaliseBundle(1);
 
-    // this additional event should not go into the bundle 
+    // this additional event should not go into the bundle
     await scenario.addEvent(0, 1, {timestamp: 3}, [{type: '4'}]);
   });
 

--- a/test/integration/cors.js
+++ b/test/integration/cors.js
@@ -44,7 +44,7 @@ describe('CORS - Integrations', async () => {
   it('Does nothing if the Origin request header is missing', async () => {
     const response = await apparatus.request()
       .post('/token')
-      .set('authorization', `AMB ${pkPair.secret}`) 
+      .set('authorization', `AMB ${pkPair.secret}`)
       .send(requestData);
     expect(response.header).to.not.have.property('access-control-allow-origin');
   });

--- a/test/integration/events/findByEntries.js
+++ b/test/integration/events/findByEntries.js
@@ -49,7 +49,7 @@ describe('Events Integrations: Find by data entries', () => {
       acceleration: {
         valueX: '1',
         valueY: 2
-      }      
+      }
     }]);
   });
 
@@ -96,7 +96,7 @@ describe('Events Integrations: Find by data entries', () => {
     await scenario.addEvent(0, 0, {timestamp: 1, accessLevel: 0}, [{
       type: 'ambrosus.event.illustration',
       confirmationAddress: '0x2222222222222222222222222222222222222222',
-      confirmationSignature: '0x39FFe6D49f20a83471D3a32f8CfDd987504fC822f8CfDd987504fC82'      
+      confirmationSignature: '0x39FFe6D49f20a83471D3a32f8CfDd987504fC822f8CfDd987504fC82'
     }]);
     const response = await get('/events?data[type]=ambrosus.event.illustration&fromTimestamp=1');
     expect(response.body.resultCount).to.eq(1);
@@ -189,9 +189,9 @@ describe('Events Integrations: Find by data entries', () => {
     });
   });
 
-  afterEach(async () => {    
+  afterEach(async () => {
     await apparatus.cleanDB();
-    scenario.reset();    
+    scenario.reset();
   });
 
   after(async () => {

--- a/test/middlewares/access_token_middleware.js
+++ b/test/middlewares/access_token_middleware.js
@@ -62,7 +62,7 @@ describe('Access token middleware', () => {
   it('throws if authenticator rejects', () => {
     mockTokenAuthenticator.decodeToken.throws(new AuthenticationError());
     const configuredMiddleware = accessTokenMiddleware(mockTokenAuthenticator);
-    expect(() => configuredMiddleware(request, response, next)).to.throw(AuthenticationError);    
+    expect(() => configuredMiddleware(request, response, next)).to.throw(AuthenticationError);
   });
 
   it('throws AuthenticationError if no token provided', async () => {

--- a/test/middlewares/error_handling.js
+++ b/test/middlewares/error_handling.js
@@ -62,8 +62,8 @@ describe('Error handling middleware', () => {
 
   it('should return 500 if other error', async () => {
     sinon.stub(console, 'error');
-    errorHandling(new Error(), request, response, next);    
-    expect(console.error).to.be.calledOnce;    
+    errorHandling(new Error(), request, response, next);
+    expect(console.error).to.be.calledOnce;
     console.error.restore();
     expect(response._getStatusCode()).to.eq(500);
     expect(next).to.be.calledOnce;

--- a/test/middlewares/prehasher_middleware.js
+++ b/test/middlewares/prehasher_middleware.js
@@ -49,7 +49,7 @@ describe('Prehasher middleware', () => {
   it('adds hash based on provided paths', () => {
     const configuredMiddleware = prehasherMiddleware(mockIdentityManager, 'content.idData', 'id');
     configuredMiddleware(request, response, next);
-    
+
     expect(request.body).to.include.key('id');
     expect(request.body.id).to.equal(exampleHash);
     expect(next).to.be.calledOnce;

--- a/test/middlewares/query_parameter_processor_middleware.js
+++ b/test/middlewares/query_parameter_processor_middleware.js
@@ -30,17 +30,17 @@ describe('Query Parameter Processor Middleware', () => {
     response = httpMocks.createResponse();
     next = sinon.spy();
   });
-  
+
   it('ensures non of passed parameters is object', async () => {
     const request = createRequest({
       data: {
-        subparam1: 'exampleString', 
+        subparam1: 'exampleString',
         subparam2: [{anotherThing : '123'}, {oneMoreThing: '456'}]
       },
       param1: 'number(5)',
       param2: 'example2String'
     });
-    
+
     expect(() => queryParameterProcessorMiddleware(request, response, next)).to.throw(ValidationError);
     expect(next).to.not.have.been.called;
   });
@@ -50,7 +50,7 @@ describe('Query Parameter Processor Middleware', () => {
       // from ?data[subparam1]=exampleString&data[subparam2]=number(2)&param1=number(5)&param2=example2String
       const request = createRequest({
         data: {
-          subparam1: 'exampleString', 
+          subparam1: 'exampleString',
           subparam2: 'number(2)'
         },
         param1: 'number(5)',
@@ -81,7 +81,7 @@ describe('Query Parameter Processor Middleware', () => {
     it('casts decorated value to {lon, lat, rad} object', async () => {
       const request = createRequest({
         data: {
-          subparam1: 'exampleString', 
+          subparam1: 'exampleString',
           subparam2: 'geo(2,10,15)'
         },
         param1: 'example2String'

--- a/test/routes/accounts.js
+++ b/test/routes/accounts.js
@@ -55,7 +55,7 @@ describe('Accounts', () => {
       await injectedHandler(req, res);
 
       expect(mockModelEngine.addAccount).to.have.been.calledWith(accountRegistrationRequest, tokenData);
-    
+
       expect(res._getStatusCode()).to.eq(201);
       expect(res._isJSON()).to.be.true;
     });
@@ -79,7 +79,7 @@ describe('Accounts', () => {
       await injectedHandler(req, res);
 
       expect(mockModelEngine.getAccount).to.have.been.calledWith(mockAccount.address, tokenData);
-    
+
       expect(res._getStatusCode()).to.eq(200);
       expect(res._isJSON()).to.be.true;
     });
@@ -131,7 +131,7 @@ describe('Accounts', () => {
       await injectedHandler(req, res);
 
       expect(mockModelEngine.modifyAccount).to.have.been.calledWith(account.address, accountModificationRequest, tokenData);
-    
+
       expect(res._getStatusCode()).to.eq(200);
       expect(res._isJSON()).to.be.true;
     });

--- a/test/services/data_model_engine.js
+++ b/test/services/data_model_engine.js
@@ -125,7 +125,7 @@ describe('Data Model Engine', () => {
         count: sinon.stub()
       };
       mockAccountAccessDefinitions = {
-        ensureCanRegisterAccount: sinon.stub(),        
+        ensureCanRegisterAccount: sinon.stub(),
         validateAddAccountRequest: sinon.stub()
       };
       modelEngine = new DataModelEngine(mockIdentityManager, {}, {}, {}, {}, {}, mockAccountRepository, {}, {}, {}, mockAccountAccessDefinitions);
@@ -908,7 +908,7 @@ describe('Data Model Engine', () => {
       });
     });
   });
-  
+
   describe('Downloading a bundle', async () => {
     const bundleId = '0x123';
     const vendorId = '0x987';

--- a/test/services/entity_builder.js
+++ b/test/services/entity_builder.js
@@ -155,7 +155,7 @@ describe('Entity Builder', () => {
         expect(() => entityBuilder.validateEvent(brokenEvent))
           .to.throw(JsonValidationError)
           .and.have.nested.property('errors[0].dataPath', '.geoJson.coordinates');
-      });      
+      });
 
       it('throws if accessLevel not positive integer', () => {
         let brokenEvent = put('content.idData.accessLevel', exampleEvent, 1.1);
@@ -359,7 +359,7 @@ describe('Entity Builder', () => {
       before(() => {
         entityBuilder.prepareEventForBundlePublication.restore();
       });
-      
+
       it('removes data if access level is greater than 0', () => {
         const ret = entityBuilder.prepareEventForBundlePublication(scenario.events[2]);
         expect(ret.content.data).to.be.undefined;

--- a/test/services/entity_downloader.js
+++ b/test/services/entity_downloader.js
@@ -30,7 +30,7 @@ describe('Entity downloader', () => {
     };
     entityDownloader = new EntityDownloader(mockHttpsClient);
   });
-  
+
   describe('download bundle', () => {
     const exampleVendorId = '0x123';
     const exampleBundleId = '0x321';

--- a/test/services/find_event_query_object.js
+++ b/test/services/find_event_query_object.js
@@ -52,7 +52,7 @@ describe('Find Event Query Object', () => {
   it('has default sorting key', () => {
     expect(findEventQueryObject.getSortingKey()).to.be.deep.equal([['content.idData.timestamp', 'descending']]);
   });
-  
+
   it('properly assembles mongodb query', () => {
     const params = {
       assetId: 12,
@@ -138,12 +138,12 @@ describe('Find Event Query Object', () => {
     describe('with additional criteria', () => {
       let scenario;
       let eventsSet;
-  
+
       const makeLocationAssetEntry = (assetIndex) => ({
         type: 'ambrosus.event.location.asset',
         asset: scenario.assets[assetIndex].assetId
       });
-  
+
       const makeLocationGeoEntry = (lon, lat) => ({
         type: 'ambrosus.event.location.geo',
         geoJson: {
@@ -151,14 +151,14 @@ describe('Find Event Query Object', () => {
           coordinates: [lon, lat]
         }
       });
-  
+
       before(async () => {
         scenario = new ScenarioBuilder(identityManager);
         await scenario.addAdminAccount(adminAccountWithSecret);
         await scenario.addAccount(0, accountWithSecret, {permissions: ['create_entity']});
         await scenario.addAsset(0, {timestamp: 0});
         await scenario.addAsset(0, {timestamp: 1});
-  
+
         eventsSet = [
           await scenario.addEvent(0, 0, {timestamp: 0, accessLevel: 0}, [makeLocationAssetEntry(0)]),
           await scenario.addEvent(0, 0, {timestamp: 1, accessLevel: 1}, [makeLocationAssetEntry(1)]),
@@ -171,16 +171,16 @@ describe('Find Event Query Object', () => {
           await scenario.addEvent(1, 1, {timestamp: 8, accessLevel: 2}, [makeLocationGeoEntry(0, 1)]),
           await scenario.addEvent(1, 1, {timestamp: 9, accessLevel: 0}, [makeLocationGeoEntry(0, 0.00005)])
         ];
-  
+
         for (const event of eventsSet) {
           await storage.storeEvent(event);
         }
       });
-  
+
       after(async () => {
         await cleanDatabase(db);
       });
-  
+
       it('with assetId param returns events for selected asset', async () => {
         const targetAssetId = scenario.assets[0].assetId;
         findEventQueryObject = findEventQueryObjectFactory.create({assetId: targetAssetId}, 10);
@@ -190,7 +190,7 @@ describe('Find Event Query Object', () => {
         expect(ret.results).to.deep.equal([eventsSet[0], eventsSet[1], eventsSet[2], eventsSet[3], eventsSet[4]].reverse());
         ret.results.forEach((element) => expect(element.content.idData.assetId).to.equal(targetAssetId));
       });
-  
+
       it('with createdBy param returns events for selected creator', async () => {
         const targetCreatorAddress = scenario.accounts[0].address;
         findEventQueryObject = findEventQueryObjectFactory.create({createdBy: targetCreatorAddress}, 10);
@@ -200,7 +200,7 @@ describe('Find Event Query Object', () => {
         expect(ret.results).to.deep.equal([eventsSet[0], eventsSet[1], eventsSet[2], eventsSet[5], eventsSet[6], eventsSet[7]].reverse());
         ret.results.forEach((element) => expect(element.content.idData.createdBy).to.equal(targetCreatorAddress));
       });
-  
+
       it('with fromTimestamp param returns only events newer than selected timestamp', async () => {
         findEventQueryObject = findEventQueryObjectFactory.create({fromTimestamp: 4}, 10);
         const ret = await findEventQueryObject.execute();
@@ -209,7 +209,7 @@ describe('Find Event Query Object', () => {
         expect(ret.results).to.deep.equal([eventsSet[4], eventsSet[5], eventsSet[6], eventsSet[7], eventsSet[8], eventsSet[9]].reverse());
         ret.results.forEach((element) => expect(element.content.idData.timestamp).to.be.at.least(4));
       });
-  
+
       it('with toTimestamp param returns only events older than selected timestamp', async () => {
         findEventQueryObject = findEventQueryObjectFactory.create({toTimestamp: 2}, 10);
         const ret = await findEventQueryObject.execute();
@@ -218,7 +218,7 @@ describe('Find Event Query Object', () => {
         expect(ret.results).to.deep.equal([eventsSet[0], eventsSet[1], eventsSet[2]].reverse());
         ret.results.forEach((element) => expect(element.content.idData.timestamp).to.be.at.most(2));
       });
-  
+
       it('with fromTimestamp param and toTimestamp param returns events from between selected timestamps', async () => {
         findEventQueryObject = findEventQueryObjectFactory.create({fromTimestamp: 2, toTimestamp: 4}, 10);
         const ret = await findEventQueryObject.execute();
@@ -227,7 +227,7 @@ describe('Find Event Query Object', () => {
         expect(ret.results).to.deep.equal([eventsSet[2], eventsSet[3], eventsSet[4]].reverse());
         ret.results.forEach((element) => expect(element.content.idData.timestamp).to.be.within(2, 4));
       });
-  
+
       it('with perPage returns requested number of events', async () => {
         findEventQueryObject = findEventQueryObjectFactory.create({perPage: 3}, 10);
         const ret = await findEventQueryObject.execute();
@@ -235,7 +235,7 @@ describe('Find Event Query Object', () => {
         expect(ret.resultCount).to.equal(10);
         expect(ret.results).to.deep.equal([eventsSet[7], eventsSet[8], eventsSet[9]].reverse());
       });
-  
+
       it('with page and perPage returns limited requested of events from requested page', async () => {
         findEventQueryObject = findEventQueryObjectFactory.create({page: 2, perPage: 3}, 10);
         const ret = await findEventQueryObject.execute();
@@ -243,7 +243,7 @@ describe('Find Event Query Object', () => {
         expect(ret.resultCount).to.equal(10);
         expect(ret.results).to.deep.equal([eventsSet[1], eventsSet[2], eventsSet[3]].reverse());
       });
-  
+
       it('with all params provided returns events for selected asset and creator, from between selected timestamps and with requested paging', async () => {
         const targetAssetId = scenario.assets[0].assetId;
         const targetCreatorAddress = scenario.accounts[1].address;
@@ -255,7 +255,7 @@ describe('Find Event Query Object', () => {
         expect(ret.results[1]).to.deep.equal(eventsSet[3]);
         ret.results.forEach((element) => expect(element.content.idData.timestamp).to.be.within(1, 4));
       });
-  
+
       it('search by data entry', async () => {
         const targetAssetId = scenario.assets[0].assetId;
         findEventQueryObject = findEventQueryObjectFactory.create({data: {asset: targetAssetId}}, 1);
@@ -264,7 +264,7 @@ describe('Find Event Query Object', () => {
         expect(ret.resultCount).to.equal(3);
         expect(ret.results).to.deep.equal([eventsSet[6], eventsSet[4], eventsSet[0]]);
       });
-  
+
       it('search by geo location', async () => {
         findEventQueryObject = findEventQueryObjectFactory.create({data: {geoJson: {locationLongitude : 0, locationLatitude: 0, locationMaxDistance: 1000}}}, 3);
         const ret = await findEventQueryObject.execute();

--- a/test/services/find_query_object.js
+++ b/test/services/find_query_object.js
@@ -71,7 +71,7 @@ describe('FindQueryObject', () => {
   it('assembles options for query', () => {
     const mockGetSortingKey = sinon.stub(findQueryObject, 'getSortingKey');
     mockGetSortingKey.returns(mockSortingKey);
-    
+
     const res = findQueryObject.assembleOptionsForQuery();
     expect(res).to.deep.equal(assembledOptions);
 

--- a/test/utils/config.js
+++ b/test/utils/config.js
@@ -26,5 +26,5 @@ describe('Config', () => {
   it('withAttibutes (override)', () => {
     const config = new Config({attribute: 2}).withAttributes({attribute: 1});
     expect(config.attributes).to.deep.eq({attribute: 1});
-  });  
+  });
 });

--- a/test/utils/validations.js
+++ b/test/utils/validations.js
@@ -55,12 +55,12 @@ describe('validation', () => {
       expect(() => output = validateIntegerParameterAndCast(6969, 'sampleErrMsg')).to.not.throw();
       expect(output).to.equal(6969);
     });
-  
+
     it('works for parsable string parameter', () => {
       expect(() => output = validateIntegerParameterAndCast('6969', 'sampleErrMsg')).to.not.throw();
       expect(output).to.equal(6969);
     });
-  
+
     it('throws if parameter not parsable', () => {
       expect(() => validateIntegerParameterAndCast('NaN', 'sampleErrMsg')).to.throw(ValidationError);
     });

--- a/test/workers/bundle_downloader.js
+++ b/test/workers/bundle_downloader.js
@@ -99,8 +99,8 @@ describe('Bundle downloader - integration', () => {
       .post('/assets')
       .send(asset);
     const bundle3 = await apparatus.dataModelEngine.finaliseBundle(3);
-  
-    await bundleDownloader.downloadAllNew();  
+
+    await bundleDownloader.downloadAllNew();
     let bundle = await dataModelEngine.entityRepository.getBundle(bundleId);
     expect(bundle.bundleId).to.eq(bundleId);
     bundle = await dataModelEngine.entityRepository.getBundle(bundle2.bundleId);

--- a/test/workers/periodic_worker.js
+++ b/test/workers/periodic_worker.js
@@ -61,7 +61,7 @@ describe('Periodic Worker', () => {
 
   it('should execute the work method exactly every 10 seconds', async () => {
     await expect(worker.start()).to.be.fulfilled;
-    
+
     expect(workStub).to.not.have.been.called;
     clock.tick(interval);
     expect(workStub).to.have.been.calledOnce;


### PR DESCRIPTION
Whitespace differences can be picked up by source control systems and flagged as diffs which is annoying. Eslint offers the --fix option that strips any trailing whitespace automatically. If your editor is configured to use eslint you can autoconfigure it to strip trailing spaces.
