### PR TITLE
Expose Prometheus metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "express": "^4.16.2",
     "mongodb": "^3.0.2",
     "pkginfo": "^0.4.1",
+    "prom-client": "^11.1.1",
     "web3": "^1.0.0-beta.34"
   },
   "devDependencies": {

--- a/src/middlewares/prometheus_middleware.js
+++ b/src/middlewares/prometheus_middleware.js
@@ -1,0 +1,36 @@
+/*
+Copyright: Ambrosus Technologies GmbH
+Email: tech@ambrosus.com
+
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+This Source Code Form is “Incompatible With Secondary Licenses”, as defined by the Mozilla Public License, v. 2.0.
+*/
+const excludedPaths = ['/health', '/metrics'];
+
+const prometheusMiddleware = (promClient, register) => {
+  const httpRequestDurationSeconds = new promClient.Histogram({
+    register: [register],
+    name: 'http_request_duration_seconds',
+    help: 'Request duration in seconds',
+    buckets: promClient.linearBuckets(0.1, 0.2, 20),
+    labelNames: ['path', 'status']
+  });
+
+  return (req, res, next) => {
+    if (!excludedPaths.includes(req.path)) {
+      // Save req.path in a local variable because it changed during
+      // `res.on('finish')` to `/`.
+      const {path} = req;
+      const endTimer = httpRequestDurationSeconds.startTimer();
+
+      res.on('finish', () => endTimer({
+        path,
+        status: res.statusCode
+      }));
+    }
+    next();
+  };
+};
+
+export default prometheusMiddleware;

--- a/src/routes/prometheus_metrics.js
+++ b/src/routes/prometheus_metrics.js
@@ -1,0 +1,15 @@
+
+/*
+Copyright: Ambrosus Technologies GmbH
+Email: tech@ambrosus.com
+
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+This Source Code Form is “Incompatible With Secondary Licenses”, as defined by the Mozilla Public License, v. 2.0.
+*/
+const prometheusMetricsHandler = (promClient) => (req, res) => {
+  res.set('Content-Type', promClient.register.contentType);
+  res.end(promClient.register.metrics());
+};
+
+export default prometheusMetricsHandler;

--- a/test/integration/prometheus_metrics.js
+++ b/test/integration/prometheus_metrics.js
@@ -1,0 +1,44 @@
+/*
+Copyright: Ambrosus Technologies GmbH
+Email: tech@ambrosus.com
+
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+This Source Code Form is “Incompatible With Secondary Licenses”, as defined by the Mozilla Public License, v. 2.0.
+*/
+import chai from 'chai';
+import Apparatus from '../helpers/apparatus';
+
+const {expect} = chai;
+
+describe('Prometheus middleware tests', () => {
+  let apparatus;
+
+  beforeEach(async () => {
+    apparatus = new Apparatus();
+    await apparatus.start();
+  });
+
+  afterEach(async () => {
+    await apparatus.stop();
+  });
+
+  it('metrics endpoint', async () => {
+    // Trigger a request which will add an entry of our request duration
+    // histogram. /metrics and /health are excluded.
+    await apparatus.request().get('/nodeInfo');
+
+    const response = await apparatus.request().get('/metrics');
+    expect(response.status).to.eql(200);
+
+    // Built in library metrics
+    expect(response.text.indexOf('process_cpu_user_seconds_total') > -1)
+      .to.eql(true);
+
+    // Custom metrics
+    expect(response.text.indexOf(
+      'http_request_duration_seconds_count{path="/nodeInfo",status="200"} 1'
+    ) > -1)
+      .to.eql(true);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1079,6 +1079,10 @@ bindings@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
 
+bintrees@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
+
 bip39@~2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/bip39/-/bip39-2.4.0.tgz#a0b8adbf163f53495f00f05d9ede7c25369ccf13"
@@ -4963,6 +4967,12 @@ progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
+prom-client@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-11.1.1.tgz#21b7e9dc0ceaae3c72a5ccd2e796d79bf1584eae"
+  dependencies:
+    tdigest "^0.1.1"
+
 promise-to-callback@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/promise-to-callback/-/promise-to-callback-1.0.0.tgz#5d2a749010bfb67d963598fcd3960746a68feef7"
@@ -6097,6 +6107,12 @@ tar@^2.1.1, tar@^2.2.1:
     block-stream "*"
     fstream "^1.0.2"
     inherits "2"
+
+tdigest@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.1.tgz#2e3cb2c39ea449e55d1e6cd91117accca4588021"
+  dependencies:
+    bintrees "1.0.1"
 
 temp@^0.8.3:
   version "0.8.3"


### PR DESCRIPTION
Exposes Prometheus metrics on the /metrics endpoint.

The prometheus client collects default metrics on Node.js such as heap
and cpu usage.

For a detailed list of default metrics see:
https://github.com/siimon/prom-client/tree/master/lib/metrics

Additionally I've added http request duration metrics which should give
us:

- mean request duration
- median request duration
- request duration quantiles
- number of HTTP requests per second

We can now also alert when ambnode is down by using the Prometheus
metric UP.