### PR TITLE
Prometheus: Separate request status from request duration

### DIFF
--- a/test/integration/prometheus_metrics.js
+++ b/test/integration/prometheus_metrics.js
@@ -36,9 +36,10 @@ describe('Prometheus middleware tests', () => {
       .to.eql(true);
 
     // Custom metrics
-    expect(response.text.indexOf(
-      'http_request_duration_seconds_count{status="200"} 1'
-    ) > -1)
+    expect(response.text.indexOf('http_request_duration_seconds_count 1') > -1)
+      .to.eql(true);
+
+    expect(response.text.indexOf('http_requests_total{status="200"} 1') > -1)
       .to.eql(true);
   });
 });


### PR DESCRIPTION
It takes a lot of time to generate request duration metrics. I'm
suspecting it is because we have too many timeseries in the histogram.
To mitigate this we:

- Separate the request status code into a separate counter metric which
  counts the total number of requests. We remove this label from the
  request duration histogram to further reduce the number of timeseries
  produced.

- Reduce the total number of buckets from 20 to 15.