### PR TITLE
Mongo auth, ssl and support for replica sets

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -13,7 +13,19 @@ module.exports = Object.freeze({
   web3Rpc: process.env.WEB3_RPC,
   nodePrivateKey: process.env.WEB3_NODEPRIVATEKEY,
 
-  mongoUri: process.env.MONGODB_URI,
+  // Required, one or more hosts delimited with comma, e.g
+  // 'mongo1:27107,mongo2:27017'
+  mongoHosts: process.env.MONGO_HOSTS,
+  mongoDbName: process.env.MONGO_DB_NAME,
+
+  // Optionally connect to a replica set
+  mongoReplicaSet: process.env.MONGO_REPLICA_SET,
+
+  // Optionally enable x509 authentication
+  mongoX509User: process.env.MONGO_X509_USER,
+  mongoX509SslCaPath: process.env.MONGO_X509_SSL_CA_PATH,
+  mongox509SslCertPath: process.env.MONGO_x509_SSL_CERT_PATH,
+  mongox509SslKeyPath: process.env.MONGO_X509_SSL_KEY_PATH,
 
   headContractAddress: process.env.HEAD_CONTRACT_ADDRESS,
   bundleSizeLimit: parseInt(process.env.BUNDLE_SIZE_LIMIT, 10) || 10000,

--- a/test/mocha_env.js
+++ b/test/mocha_env.js
@@ -9,5 +9,6 @@ This Source Code Form is “Incompatible With Secondary Licenses”, as defined 
 process.env.NODE_ENV = 'test';
 process.env.WEB3_RPC = 'ganache';
 process.env.WEB3_NODEPRIVATEKEY = '0xfa654acfc59f0e4fe3bd57082ad28fbba574ac55fe96e915f17de27ad9c77696';
-process.env.MONGODB_URI = 'mongodb://localhost:27017/ambrosus';
+process.env.MONGO_HOSTS = 'localhost:27017';
+process.env.MONGO_DB_NAME = 'ambrosus';
 process.env.AUTHORIZATION_WITH_SECRET_KEY_ENABLED = true;


### PR DESCRIPTION
Merge https://github.com/ambrosus/ambrosus-node/pull/178 first and rebase on top of that.

The diff will be much smaller once the preceding PR is closed.

This commit adds support for usage of replica sets (RS), SSL and authentication using x509. All three features are opt-in, meaning if you don't provide them they will be omitted when connecting.
I.e
- provide MONGO_X509_USER to enable x509 authentication and SSL
- provide MONGO_REPLICA_SET with the name of the replica set to connect to a RS

x509 authentication is recommended for a production setup. Both the client and the server will use certificates to authenticate and both certificates must be signed by the same certificate authority. SSL is a requirement for this kind of authentication.

- For the client, the servers COMMON NAME in the certificate must match what's provided in the connection string as the host.
- For the server the clients COMMON NAME must match the client certificate and the client must be added to the $external auth database. 

 https://docs.mongodb.com/manual/tutorial/configure-x509-client-authentication/

