### PR TITLE
minor doc improvement

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -191,9 +191,9 @@ Finds accounts satisfying provided criteria.
 
 + Parameters
 
-    + accessLevel (string, optional) - Finds only accounts with access level not smaller than parameter
-    + perPage (integer, optional) - number of assets to return per page
-    + page (integer, optional) - number of page (more search results than specified in perPage parameter concludes more than one page)
+    + accessLevel (string, optional) - Finds only accounts with access level not smaller than provided parameter value
+    + perPage (integer, optional) - Number of accounts to return per page
+    + page (integer, optional) - Number of page (more search results than specified in perPage parameter concludes more than one page)
 
 + Request (application/json)
 


### PR DESCRIPTION
Generally I can't see what we can really improve around filtering accounts by accessLevel.
Parameter has short, but descriptive name. Expanding it to minimumAccessLevel IMO makes no sense, while it is well described in docs (here I gave a teensy improving touch). It is also properly validated and properly handled. Correct if I'm wrong.