### PR TITLE
Add MongoDB authentication and support for replica sets

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -13,7 +13,17 @@ module.exports = Object.freeze({
   web3Rpc: process.env.WEB3_RPC,
   nodePrivateKey: process.env.WEB3_NODEPRIVATEKEY,
 
-  mongoUri: process.env.MONGODB_URI,
+  // Required, one or more hosts delimited with comma, e.g
+  // 'mongo1:27107,mongo2:27017'
+  mongoHosts: process.env.MONGO_HOSTS,
+  mongoDBName: process.env.MONGO_DB_NAME,
+
+  // Optionally connect to a replica set
+  mongoReplicaSet: process.env.MONGO_REPLICA_SET,
+
+  // Optionally enable authentication
+  mongoUser: process.env.MONGO_USER,
+  mongoPassword: process.env.MONGO_PASSWORD,
 
   headContractAddress: process.env.HEAD_CONTRACT_ADDRESS,
   challengeResolutionStrategy: process.env.CHALLENGE_RESOLUTION_STRATEGY || 'resolve_all_strategy',

--- a/test/mocha_env.js
+++ b/test/mocha_env.js
@@ -9,5 +9,6 @@ This Source Code Form is “Incompatible With Secondary Licenses”, as defined 
 process.env.NODE_ENV = 'test';
 process.env.WEB3_RPC = 'ganache';
 process.env.WEB3_NODEPRIVATEKEY = '0xfa654acfc59f0e4fe3bd57082ad28fbba574ac55fe96e915f17de27ad9c77696';
-process.env.MONGODB_URI = 'mongodb://localhost:27017/ambrosus';
+process.env.MONGO_HOSTS = 'localhost:27017';
+process.env.MONGO_DB_NAME = 'ambrosus';
 process.env.AUTHORIZATION_WITH_SECRET_KEY_ENABLED = true;

--- a/test/utils/db_utils.js
+++ b/test/utils/db_utils.js
@@ -1,0 +1,53 @@
+/*
+Copyright: Ambrosus Technologies GmbH
+Email: tech@ambrosus.com
+
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+This Source Code Form is “Incompatible With Secondary Licenses”, as defined by the Mozilla Public License, v. 2.0.
+*/
+
+import {expect} from 'chai';
+import {createMongoUrl} from '../../src/utils/db_utils';
+
+describe('#createMongoUrl', () => {
+  it('parses config with credentials and replica set', () => {
+    const url = createMongoUrl({
+      mongoHosts: 'mongo1.com,mongo2.com',
+      mongoReplicaSet: 'my_replica_set',
+      mongoUser: 'salvador',
+      mongoPassword: 'allende'
+    });
+    expect(url).to.eql(
+      'mongodb://salvador:allende@mongo1.com,mongo2.com/?replicaSet=my_replica_set&authSource=admin'
+    );
+  });
+
+  it('parses config with credentials', () => {
+    const url = createMongoUrl({
+      mongoHosts: 'mongo1.com,mongo2.com',
+      mongoUser: 'salvador',
+      mongoPassword: 'allende'
+    });
+    expect(url).to.eql(
+      'mongodb://salvador:allende@mongo1.com,mongo2.com/?authSource=admin'
+    );
+  });
+
+  it('parses config with replica set', () => {
+    const url = createMongoUrl({
+      mongoHosts: 'mongo1.com,mongo2.com',
+      mongoReplicaSet: 'my_replica_set'
+    });
+    expect(url).to.eql(
+      'mongodb://mongo1.com,mongo2.com/?replicaSet=my_replica_set'
+    );
+  });
+
+  it('parses config without credentials and replica set', () => {
+    const url = createMongoUrl({
+      mongoHosts: 'mongo1.com,mongo2.com'
+    });
+    expect(url).to.eql('mongodb://mongo1.com,mongo2.com/?');
+  });
+});


### PR DESCRIPTION
Adds Mongo authentication using a username / password combination and
support for connecting to replica sets.

Both features are drop-in meaning that if

- MONGO_USER is not provided in the environment authentication is not
  enabled.

- MONGO_REPLICA_SET is not provided in the environment we will connect
  to a standalone Mongo.