### PR TITLE
Regular Interval Strategy minimum items count setting.

### DIFF
--- a/src/workers/hermes_strategies/regular_interval_upload_strategy.js
+++ b/src/workers/hermes_strategies/regular_interval_upload_strategy.js
@@ -19,7 +19,8 @@ export default class RegularIntervalUploadStrategy extends HermesUploadStrategy 
   }
 
   async shouldBundle(bundle) {
-    return bundle.content.entries.length > 0;
+    const minimumItemsInBundle = process.env.WORKER_MINIMUM_ITEMS || 1;
+    return bundle.content.entries.length >= minimumItemsInBundle;
   }
 
   async bundlingSucceeded() {


### PR DESCRIPTION
Allows the minimal number of items inside of a bundle that is considered to be valid by the regular interval strategy to be set using an ENV variable.