### PR TITLE
Atlas worker now picks one challenge at a time for resolution

### DIFF
--- a/src/services/data_model_engine.js
+++ b/src/services/data_model_engine.js
@@ -232,16 +232,6 @@ export default class DataModelEngine {
     await this.entityRepository.storeBundleShelteringExpirationDate(bundleId, expirationDate);
   }
 
-  async cleanupBundles() {
-    const expiredBundleIds = await this.entityRepository.getExpiredBundleIds();
-    const isSheltering = await Promise.all(expiredBundleIds.map((bundleId) => this.uploadRepository.isSheltering(bundleId)));
-    const toBeRemoved = expiredBundleIds.filter((bundleId, ind) => !isSheltering[ind]);
-    const toBeUpdated = expiredBundleIds.filter((bundleId, ind) => isSheltering[ind]);
-    await this.entityRepository.deleteBundles(toBeRemoved);
-    await Promise.all(toBeUpdated.map((bundleId) => this.updateShelteringExpirationDate(bundleId)));
-    return toBeRemoved;
-  }
-
   async getWorkerLogs(logsCount = 10) {
     return await this.workerLogRepository.getLogs(logsCount);
   }

--- a/test/services/data_model_engine.js
+++ b/test/services/data_model_engine.js
@@ -1260,54 +1260,6 @@ describe('Data Model Engine', () => {
     });
   });
 
-  describe('Cleanup unnecessary bundles', () => {
-    const allBundles = ['bundle1', 'bundle2', 'bundle3'];
-    let mockEntityRepository;
-    let mockUploadRepository;
-    let modelEngine;
-
-    beforeEach(() => {
-      mockEntityRepository = {
-        getExpiredBundleIds: sinon.stub().resolves(allBundles),
-        deleteBundles: sinon.stub()
-      };
-
-      mockUploadRepository = {
-        isSheltering: sinon.stub().resolves(true)
-      };
-
-      modelEngine = new DataModelEngine({
-        entityRepository: mockEntityRepository,
-        uploadRepository: mockUploadRepository
-      });
-
-      sinon.stub(modelEngine, 'updateShelteringExpirationDate');
-    });
-
-    it('checks if is still sheltering for all bundles', async () => {
-      await modelEngine.cleanupBundles();
-      expect(mockEntityRepository.getExpiredBundleIds).to.be.calledOnce;
-      expect(mockUploadRepository.isSheltering).to.be.calledThrice;
-      expect(mockUploadRepository.isSheltering).to.be.calledWith('bundle1');
-      expect(mockUploadRepository.isSheltering).to.be.calledWith('bundle2');
-      expect(mockUploadRepository.isSheltering).to.be.calledWith('bundle3');
-    });
-
-    it('deletes not sheltered bundles and returns their ids', async () => {
-      mockUploadRepository.isSheltering.withArgs('bundle3').resolves(false);
-      expect(await modelEngine.cleanupBundles()).to.deep.equal(['bundle3']);
-      expect(mockEntityRepository.deleteBundles).to.be.calledOnceWith(['bundle3']);
-    });
-
-    it('updates expiration date on all bundles marked as expired but still sheltered', async () => {
-      mockUploadRepository.isSheltering.withArgs('bundle3').resolves(false);
-      await modelEngine.cleanupBundles();
-      expect(modelEngine.updateShelteringExpirationDate).to.be.calledTwice;
-      expect(modelEngine.updateShelteringExpirationDate).to.be.calledWith('bundle2');
-      expect(modelEngine.updateShelteringExpirationDate).to.be.calledWith('bundle1');
-    });
-  });
-
   describe('Getting worker logs', () => {
     let modelEngine;
     let mockWorkerLogRepository;

--- a/yarn.lock
+++ b/yarn.lock
@@ -254,7 +254,7 @@ ajv@^5.2.3, ajv@^5.3.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
-ajv@^6.4.0, ajv@^6.5.5:
+ajv@^6.5.5:
   version "6.5.5"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.5.tgz#cf97cdade71c6399a92c6d6c4177381291b781a1"
   integrity sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==
@@ -465,7 +465,7 @@ async-eventemitter@^0.2.2:
   dependencies:
     async "^2.4.0"
 
-"async-eventemitter@github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c":
+async-eventemitter@ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c:
   version "0.2.3"
   resolved "https://codeload.github.com/ahultgren/async-eventemitter/tar.gz/fa06e39e56786ba541c180061dbf2c0a5bbf951c"
   dependencies:


### PR DESCRIPTION
This improves on the way Atlas workers peek challenges to be resolved. 

Instead of querying and checking all the challenges upfront and then just iterating over them (takes 3 + N queries to parity), it now makes the query first (3 queries to parity) and performs the check just before potential resolution attempts. It stops on first successful resolution (due to cooldown being in place, further resolutions doesn't make sense. 

The initial query also takes into account that some challenge candidates may have been already resolved by the current node. Which removes them from the query.

Note: this PR also removes the current cleanup mechanism for bundles as this was implemented in a very inefficient manner.