### PR TITLE
Use alpine base image to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:10
+FROM node:10-alpine
+
+RUN apk add git=~2.18 python=~2.7 make=~4.2 g++=~6.4 --no-cache
 
 WORKDIR /app
 


### PR DESCRIPTION
```
21:18:52 ~/ambrosus-node ip-10-0-135-92 % docker images | grep ambrosus/ambrosus-node
ambrosus/ambrosus-node   alpine    a64f214ef5f2   57 seconds ago   560MB
ambrosus/ambrosus-node   latest    cd99393810be   9 hours ago      966MB
```