### PR TITLE
Prettify JSON API output

### DIFF
--- a/src/workers/server_worker.js
+++ b/src/workers/server_worker.js
@@ -49,6 +49,7 @@ export default class ServerWorker extends Worker {
     this.collectMetricsInterval = promClient.collectDefaultMetrics({timeout: 10000});
     const app = express();
 
+    app.set('json spaces', 2);
     app.use(Sentry.Handlers.requestHandler());
     app.use(loggerMiddleware(this.logger));
     app.use(prometheusMiddleware(promClient));


### PR DESCRIPTION
> The 'space' argument used by `JSON.stringify`. This is typically set
> to the number of spaces to use to indent prettified JSON.

https://expressjs.com/en/api.html