### PR TITLE
Stop on first fail when uploading many bundles.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,6 +44,7 @@
     "no-useless-constructor": 2,
     "no-dupe-class-members": 2,
     "no-duplicate-imports": 2,
+    "no-constant-condition": "off",
     "import/no-mutable-exports": 2,
     "import/prefer-default-export": 1,
     "import/first": 2,

--- a/src/services/data_model_engine.js
+++ b/src/services/data_model_engine.js
@@ -213,19 +213,17 @@ export default class DataModelEngine {
     await this.entityRepository.discardBundling(bundleStubId);
   }
 
-  async uploadAcceptedBundleCandidates(uploadProgressControls = {success: async () => {}, fail: async () => {}, stopOnFail: false}) {
+  async uploadAcceptedBundleCandidates(uploadProgressCallbacks = {success: async () => {}, fail: async () => {}}) {
     const waitingBundlesMetadata = await this.bundleRepository.findBundlesWaitingForUpload();
     for (const {bundleId, storagePeriods} of waitingBundlesMetadata) {
       try {
         const {blockNumber, transactionHash, timestamp, uploadResult} = await this.uploadRepository.ensureBundleIsUploaded(bundleId, storagePeriods);
         await this.entityRepository.storeBundleProofMetadata(bundleId, blockNumber, timestamp, transactionHash);
         await this.bundleRepository.storeBundleProofMetadata(bundleId, blockNumber, timestamp, transactionHash);
-        await uploadProgressControls.success(bundleId, uploadResult);
+        await uploadProgressCallbacks.success(bundleId, uploadResult);
       } catch (err) {
-        await uploadProgressControls.fail(bundleId, err);
-        if (uploadProgressControls.stopOnFail) {
-          break;
-        }
+        await uploadProgressCallbacks.fail(bundleId, err);
+        break;
       }
     }
   }

--- a/src/workers/hermes_worker.js
+++ b/src/workers/hermes_worker.js
@@ -77,7 +77,8 @@ export default class HermesWorker extends PeriodicWorker {
   async uploadWaitingCandidates() {
     await this.dataModelEngine.uploadAcceptedBundleCandidates({
       success: async (bundleId, uploadResult) => this.addLog(uploadResult, {bundleId}),
-      fail: async (bundleId, error) => this.addLog(`Bundle failed to upload`, {bundleId, errorMsg: error.message || error}, error.stack)
+      fail: async (bundleId, error) => this.addLog(`Bundle failed to upload`, {bundleId, errorMsg: error.message || error}, error.stack),
+      stopOnFail: true
     });
   }
 

--- a/src/workers/hermes_worker.js
+++ b/src/workers/hermes_worker.js
@@ -77,8 +77,7 @@ export default class HermesWorker extends PeriodicWorker {
   async uploadWaitingCandidates() {
     await this.dataModelEngine.uploadAcceptedBundleCandidates({
       success: async (bundleId, uploadResult) => this.addLog(uploadResult, {bundleId}),
-      fail: async (bundleId, error) => this.addLog(`Bundle failed to upload`, {bundleId, errorMsg: error.message || error}, error.stack),
-      stopOnFail: true
+      fail: async (bundleId, error) => this.addLog(`Bundle failed to upload`, {bundleId, errorMsg: error.message || error}, error.stack)
     });
   }
 

--- a/test/services/data_model_engine.js
+++ b/test/services/data_model_engine.js
@@ -1254,7 +1254,7 @@ describe('Data Model Engine', () => {
         bundleRepository: mockBundleRepository
       });
 
-      await modelEngine.uploadAcceptedBundleCandidates({success: async() => {}, fail: async() => {}, stopOnFail: true});
+      await modelEngine.uploadAcceptedBundleCandidates({success: async() => {}, fail: async() => {}});
       expect(mockUploadRepository.ensureBundleIsUploaded).to.have.callCount(1);
       expect(mockEntityRepository.storeBundleProofMetadata).not.to.be.have.been.calledWith('bundle2', blockNumber, txHash);
     });

--- a/test/services/data_model_engine.js
+++ b/test/services/data_model_engine.js
@@ -1230,6 +1230,36 @@ describe('Data Model Engine', () => {
       expect(progressCallbacks.success).to.have.been.calledOnceWith('bundle1', 'Success');
       expect(progressCallbacks.fail).to.have.been.calledOnceWith('bundle3', bundle3Error);
     });
+
+    it('retries uploads when rate limited', async () => {
+      mockEntityRepository = {
+        findBundlesWaitingForUpload: sinon.stub().resolves([
+          {
+            bundleId: 'bundle1',
+            metadata: {storagePeriods: 2}
+          }
+        ]),
+        storeBundleProofMetadata: sinon.stub()
+      };
+
+      const uploadBundle = sinon.stub();
+      const rateLimitError = new Error(
+        'Invalid JSON RPC response: "<html>\r\n<head><title>429 Too Many Requests</title></head>'
+      );
+      uploadBundle.onCall(0).rejects(rateLimitError);
+      uploadBundle.onCall(1).rejects(rateLimitError);
+      uploadBundle.onCall(2).resolves({blockNumber, transactionHash: txHash});
+
+      mockUploadRepository = {uploadBundle};
+      modelEngine = new DataModelEngine({
+        entityRepository: mockEntityRepository,
+        uploadRepository: mockUploadRepository
+      });
+
+      await modelEngine.uploadAcceptedBundleCandidates();
+      expect(mockUploadRepository.uploadBundle).to.have.callCount(3);
+      expect(mockEntityRepository.storeBundleProofMetadata).to.be.have.been.calledOnceWith('bundle1', blockNumber, txHash);
+    });
   });
 
   describe('Downloading a bundle', () => {

--- a/test/workers/hermes_worker.js
+++ b/test/workers/hermes_worker.js
@@ -48,8 +48,8 @@ describe('Hermes Worker', () => {
       prepareBundleCandidate: sinon.stub().resolves(mockResult),
       rejectBundleCandidate: sinon.stub().resolves(),
       acceptBundleCandidate: sinon.stub().resolves(mockResult),
-      uploadAcceptedBundleCandidates: sinon.stub().callsFake(async (callbacks) => {
-        await callbacks.success(bundleId, 'Bundle has been uploaded');
+      uploadAcceptedBundleCandidates: sinon.stub().callsFake(async (controls) => {
+        await controls.success(bundleId, 'Bundle has been uploaded');
       })
     };
     mockWorkerTaskTrackingRepository = {
@@ -139,6 +139,11 @@ describe('Hermes Worker', () => {
       await hermesWorker.periodicWork();
       expect(mockDataModelEngine.uploadAcceptedBundleCandidates).to.have.been.calledOnce;
       expect(mockLogger.info).to.have.been.calledWith({message:'Bundle has been uploaded', bundleId, stacktrace:undefined});
+    });
+
+    it('will stop on first error', async () => {
+      await hermesWorker.periodicWork();
+      expect(mockDataModelEngine.uploadAcceptedBundleCandidates).to.have.been.calledWith(sinon.match({stopOnFail: true}));
     });
   });
 

--- a/test/workers/hermes_worker.js
+++ b/test/workers/hermes_worker.js
@@ -138,12 +138,7 @@ describe('Hermes Worker', () => {
     it('is requested and summary is logged', async () => {
       await hermesWorker.periodicWork();
       expect(mockDataModelEngine.uploadAcceptedBundleCandidates).to.have.been.calledOnce;
-      expect(mockLogger.info).to.have.been.calledWith({message:'Bundle has been uploaded', bundleId, stacktrace:undefined});
-    });
-
-    it('will stop on first error', async () => {
-      await hermesWorker.periodicWork();
-      expect(mockDataModelEngine.uploadAcceptedBundleCandidates).to.have.been.calledWith(sinon.match({stopOnFail: true}));
+      expect(mockLogger.info).to.have.been.calledWith({message: 'Bundle has been uploaded', bundleId, stacktrace: undefined});
     });
   });
 


### PR DESCRIPTION
Parity RPC servers may be rate limited and sending too HTTP requests may
cause the process to fall under a rate limit. In order to avoid the rate
limits we implement incremental back off which starts at 1s and is
multiplied by 2 for each consecutive HTTP request that is rate limited.