### PR TITLE
Removes Logs Multiline

### DIFF
--- a/src/middlewares/logger_middleware.js
+++ b/src/middlewares/logger_middleware.js
@@ -25,7 +25,7 @@ export default (logger) => {
     requestHeaders: tokens['req-head'](req, res),
     responseHeaders: tokens['res-head'](req, res),
     responseTime: `${tokens['response-time'](req, res)}ms`
-  }, null, 4), {
+  }), {
     stream: {write: (message) => logger.info(message)},
     skip: (req) => ['/health', '/metrics'].includes(req.url)
   });

--- a/test/middlewares/logger_middleware.js
+++ b/test/middlewares/logger_middleware.js
@@ -42,7 +42,7 @@ describe('Logger middleware', () => {
     });
 
     await flushAllPromises();
-    expect(mockLogger.info).to.have.been.calledWithMatch('"url": "/some"');
+    expect(mockLogger.info.args[0][0]).to.include('"url":"/some"');
   });
 
   [


### PR DESCRIPTION
Logging multilines with docker becomes hard to filter with an ELK-stack. Each line becomes an individual log. A sample log taken from a docker container running an atlas/hermes server is presented below. Having a single line json log will be easier to parse, filter and present through kibana. 

As you see below the symbol "{" becomes an individual log with docker (each line is regarded as an event and becomes a log), would like to avoid this.

```
{"log":"{\n","stream":"stdout","time":"2018-12-07T14:29:51.335056861Z"}
{"log":"    \"type\": \"request\",\n","stream":"stdout","time":"2018-12-07T14:29:51.33507702Z"}
{"log":"    \"timestamp\": \"2018-12-07T14:29:51.334Z\",\n","stream":"stdout","time":"2018-12-07T14:29:51.335082458Z"}
{"log":"    \"httpVersion\": \"1.0\",\n","stream":"stdout","time":"2018-12-07T14:29:51.335087114Z"}
{"log":"    \"method\": \"POST\",\n","stream":"stdout","time":"2018-12-07T14:29:51.335091616Z"}
{"log":"    \"url\": \"/assets/0x9855017881e83099314a8c5b355eab3349045338fdb8f4127372f2caa7f15719/events\",\n","stream":"stdout","time":"2018-12-07T14:29:51.335115656Z"}
{"log":"    \"status\": \"201\",\n","stream":"stdout","time":"2018-12-07T14:29:51.335122411Z"}
{"log":"    \"remoteAddress\": \"::ffff:172.18.0.3\",\n","stream":"stdout","time":"2018-12-07T14:29:51.335126567Z"}
{"log":"    \"requestHeaders\": {\n","stream":"stdout","time":"2018-12-07T14:29:51.335130808Z"}
```
