### PR TITLE
Fix deduplication migration by using disk

### DIFF
--- a/src/migrations/20181210103000_deduplicate_assets_and_events.js
+++ b/src/migrations/20181210103000_deduplicate_assets_and_events.js
@@ -8,8 +8,8 @@ This Source Code Form is “Incompatible With Secondary Licenses”, as defined 
 */
 
 const deduplicateEntities = async (db, collectionName, uniqueKey) => {
-  const cursor = await db.collection(collectionName).aggregate(
-    [{
+  const pipeline = [
+    {
       $group: {
         _id: `$${uniqueKey}`,
         dups: {$addToSet: '$_id'},
@@ -20,8 +20,9 @@ const deduplicateEntities = async (db, collectionName, uniqueKey) => {
       $match: {
         count: {$gt: 1}
       }
-    }]
-  );
+    }
+  ];
+  const cursor = await db.collection(collectionName).aggregate(pipeline, {allowDiskUse: true});
   while (await cursor.hasNext()) {
     const document = await cursor.next();
     const toRemove = document.dups.slice(1);


### PR DESCRIPTION
# Changes

This migration fails when the migration takes memory than what the Mongo
server RAM offers. Use disk when this happens.

```
Migrating: 20181210103000_deduplicate_assets_and_events.js
{
    "type": "error",
    "message": "Exceeded memory limit for $group, but didn't allow external sort. Pass allowDiskUse:true to opt in.",
    "stackTrace": "MongoError: Exceeded memory limit for $group, but didn't allow external sort. Pass allowDiskUse:true to opt in.\n    at queryCallback (/app/node_modules/mongodb-core/lib/cursor.js:248:25)\n    at /app/node_modules/mongodb-core/lib/connection/pool.js:532:18\n    at process._tickCallback (internal/process/next_tick.js:61:11)"
}
```