### PR TITLE
Add process instrumentation

### DIFF
--- a/src/start_atlas.js
+++ b/src/start_atlas.js
@@ -7,12 +7,12 @@ This Source Code Form is subject to the terms of the Mozilla Public License, v. 
 This Source Code Form is “Incompatible With Secondary Licenses”, as defined by the Mozilla Public License, v. 2.0.
 */
 
-import {WinstonConsoleLogger} from './utils/loggers';
 import AtlasWorker from './workers/atlas_worker';
 import config from '../config/config';
 import Builder from './builder';
 import {Role} from './services/roles_repository';
 import {waitForChainSync} from './utils/web3_tools';
+import {setup} from './utils/instrument_process';
 
 async function start(logger) {
   const builder = new Builder();
@@ -43,10 +43,4 @@ function loadStrategy(strategyName) {
   return new ChallengeResolutionStrategy();
 }
 
-const logger = new WinstonConsoleLogger();
-
-start(logger)
-  .catch((err) => {
-    logger.error(err);
-    process.exit(1);
-  });
+setup(start);

--- a/src/start_hermes.js
+++ b/src/start_hermes.js
@@ -7,12 +7,12 @@ This Source Code Form is subject to the terms of the Mozilla Public License, v. 
 This Source Code Form is “Incompatible With Secondary Licenses”, as defined by the Mozilla Public License, v. 2.0.
 */
 
-import {WinstonConsoleLogger} from './utils/loggers';
 import config from '../config/config';
 import Builder from './builder';
 import HermesWorker from './workers/hermes_worker';
 import {Role} from './services/roles_repository';
 import {waitForChainSync} from './utils/web3_tools';
+import {setup} from './utils/instrument_process';
 
 async function start(logger) {
   const builder = new Builder();
@@ -40,10 +40,4 @@ function loadStrategy(uploadStrategy) {
   return new HermesUploadStrategy();
 }
 
-const logger = new WinstonConsoleLogger();
-
-start(logger)
-  .catch((err) => {
-    logger.error(err);
-    process.exit(1);
-  });
+setup(start);

--- a/src/start_server.js
+++ b/src/start_server.js
@@ -7,12 +7,12 @@ This Source Code Form is subject to the terms of the Mozilla Public License, v. 
 This Source Code Form is “Incompatible With Secondary Licenses”, as defined by the Mozilla Public License, v. 2.0.
 */
 
-import {WinstonExpressLogger} from './utils/loggers';
 import config from '../config/config';
 import Builder from './builder';
 import ServerWorker from './workers/server_worker';
 import {Role} from './services/roles_repository';
 import {waitForChainSync} from './utils/web3_tools';
+import {setup} from './utils/instrument_process';
 
 async function start(logger) {
   const builder = new Builder();
@@ -33,10 +33,4 @@ async function start(logger) {
   await worker.start();
 }
 
-const logger = new WinstonExpressLogger();
-
-start(logger)
-  .catch((err) => {
-    logger.error(err);
-    process.exit(1);
-  });
+setup(start);

--- a/src/utils/instrument_process.js
+++ b/src/utils/instrument_process.js
@@ -1,0 +1,53 @@
+
+/*
+Copyright: Ambrosus Technologies GmbH
+Email: tech@ambrosus.com
+
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+This Source Code Form is “Incompatible With Secondary Licenses”, as defined by the Mozilla Public License, v. 2.0.
+*/
+import * as Sentry from '@sentry/node';
+import {WinstonConsoleLogger} from './loggers';
+import config from '../../config/config';
+
+const reportAndExit = async (sentryClient, logger, message, error) => {
+  logger.error({message, error});
+  sentryClient.captureException(error);
+  await sentryClient.getCurrentHub().getClient()
+    .close(2000);
+  process.exit(1);
+};
+
+export const instrumentProcess = (startFn, sentryClient, logger) => {
+  sentryClient.init({
+    dsn: config.sentryDSN,
+    environment: process.env.NODE_ENV,
+    ignoreErrors: config.sentryIgnoreRegex ? new RegExp(config.sentryIgnoreRegex) : []
+  });
+
+  process.once('unhandledRejection', (error) => {
+    reportAndExit(
+      sentryClient,
+      logger,
+      'unhandledRejection bubbled up to the process',
+      error
+    );
+  });
+
+  process.once('uncaughtException', (error) => {
+    reportAndExit(
+      sentryClient,
+      logger,
+      'uncaughtException bubbled up to the process',
+      error
+    );
+  });
+
+  startFn(logger);
+};
+
+export const setup = (start) => {
+  const logger = new WinstonConsoleLogger();
+  instrumentProcess(start, Sentry, logger);
+};

--- a/src/workers/server_worker.js
+++ b/src/workers/server_worker.js
@@ -40,12 +40,6 @@ export default class ServerWorker extends Worker {
   async work() {
     this.logger.info('starting server');
 
-    Sentry.init({
-      dsn: this.config.sentryDSN,
-      environment: process.env.NODE_ENV,
-      ignoreErrors: this.config.sentryIgnoreRegex ? new RegExp(this.config.sentryIgnoreRegex) : []
-    });
-
     this.collectMetricsInterval = promClient.collectDefaultMetrics({timeout: 10000});
     const app = express();
 

--- a/test/utils/instrument_process.js
+++ b/test/utils/instrument_process.js
@@ -1,0 +1,89 @@
+/*
+Copyright: Ambrosus Technologies GmbH
+Email: tech@ambrosus.com
+
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+This Source Code Form is “Incompatible With Secondary Licenses”, as defined by the Mozilla Public License, v. 2.0.
+*/
+import chai from 'chai';
+import * as sinon from 'sinon';
+import {instrumentProcess} from '../../src/utils/instrument_process';
+import config from '../../config/config';
+
+const {expect} = chai;
+
+describe('#instrumentProcess', () => {
+  let sandbox;
+  let startFn;
+  let sentry;
+  let sentryClose;
+  let logger;
+  let unhandledRejectionListeners;
+  let uncaughtExceptionListeners;
+
+  beforeEach(() => {
+    unhandledRejectionListeners = process.listeners('unhandledRejection');
+    uncaughtExceptionListeners = process.listeners('uncaughtException');
+    process.removeAllListeners('unhandledRejection');
+    process.removeAllListeners('uncaughtException');
+
+    sandbox = sinon.createSandbox();
+    startFn = sandbox.spy();
+    sentryClose = sandbox.stub().returns(Promise.resolve());
+    sentry = {
+      init: sandbox.spy(),
+      captureException: sandbox.spy(),
+      getCurrentHub: () => ({
+        getClient: () => ({
+          close: sentryClose
+        })
+      })
+    };
+    logger = {
+      error: sandbox.spy()
+    };
+    sandbox.stub(process, 'exit');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    unhandledRejectionListeners.forEach((listener) => {
+      process.on('unhandledRejection', listener);
+    });
+    uncaughtExceptionListeners.forEach((listener) => {
+      process.on('uncaughtException', listener);
+    });
+  });
+
+  it('initiates the Sentry client', () => {
+    instrumentProcess(startFn, sentry, logger);
+    expect(sentry.init).to.have.been.calledOnceWith({
+      dsn: config.sentryDSN,
+      environment: process.env.NODE_ENV,
+      ignoreErrors: []
+    });
+  });
+
+  it('calls the startFn', () => {
+    instrumentProcess(startFn, sentry, logger);
+    expect(startFn).to.have.been.calledOnceWith(logger);
+  });
+
+  it('on unhanledRejection reports errors', () => {
+    const err = new Error('hodovic');
+    const startFn = () => {
+      Promise.reject(err);
+    };
+    instrumentProcess(startFn, sentry, logger);
+    // wait after the pending events have been processed
+    setImmediate(() => {
+      expect(logger.error).to.have.been.calledOnceWith({
+        message: 'unhandledRejection bubbled up to the process',
+        error: err
+      });
+      expect(sentry.captureException).to.have.been.calledOnceWith(err);
+      expect(sentryClose).to.have.been.calledOnceWith(2000);
+    });
+  });
+});


### PR DESCRIPTION
# Checklist:

- [ ] Code follows the style guidelines
- [x] ~Documentation updated~
- [ ] Corner cases evaluated and handled
- [x] Automatic tests added/update
- [x] Automatic tests pass
- [x] Software runs (locally or hosted)
- [x] Sanity check passed
- [x] Self-review passed

# Changes

I've seen unhandledRejection errors bubble up to the process when
operating Hermes workers in production. This causes a zombie process
which isn't operational, but continues running.

The commit introduces the following changes:

on unhandledRejection or uncaughtException errors that are not handled
and bubble up to the process, do the following:

- exit with a status code of 1 so that the process is restarted by it's
  supervisor in a fresh state (in our case by the Docker daemon)

- log the error

- report the error to Sentry (if Sentry is enabled)

Additionally we enable Sentry for the Hermes and Atlas workers rather
than having it run only on the server.