### PR TITLE
Remove pinned sha3 from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "pkginfo": "^0.4.1",
     "prom-client": "^11.1.1",
     "web3": "1.0.0-beta.34",
-    "winston": "^3.0.0",
-    "sha3": "^1.2.2"
+    "winston": "^3.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6427,7 +6427,7 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-sha3@^1.1.0, sha3@^1.2.2:
+sha3@^1.1.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/sha3/-/sha3-1.2.2.tgz#a66c5098de4c25bc88336ec8b4817d005bca7ba9"
   integrity sha1-pmxQmN5MJbyIM27ItIF9AFvKe6k=


### PR DESCRIPTION
This was added to force a newer sha3 install. sha3 is a dependency of
keccakjs and keccakjs was recently updated to include a more recent
version of sha3.

See:
https://github.com/axic/keccakjs/pull/6#issuecomment-448300538
https://github.com/axic/keccakjs/pull/6