### PR TITLE
Add Prometheus metrics for Hermes bundling

### DIFF
--- a/src/middlewares/prometheus_middleware.js
+++ b/src/middlewares/prometheus_middleware.js
@@ -8,16 +8,18 @@ This Source Code Form is “Incompatible With Secondary Licenses”, as defined 
 */
 const excludedPaths = ['/health', '/metrics'];
 
-const prometheusMiddleware = (promClient) => {
+const prometheusMiddleware = (promClient, registry) => {
   const httpRequestDurationSeconds = new promClient.Histogram({
     name: 'http_request_duration_seconds',
     help: 'Request duration in seconds',
-    buckets: promClient.linearBuckets(0.1, 0.2, 15)
+    buckets: promClient.linearBuckets(0.1, 0.2, 15),
+    registers: [registry]
   });
   const httpRequestsTotal = new promClient.Counter({
     name: 'http_requests_total',
     help: 'Total number of HTTP requests',
-    labelNames: ['status']
+    labelNames: ['status'],
+    registers: [registry]
   });
 
   return (req, res, next) => {

--- a/src/routes/prometheus_metrics.js
+++ b/src/routes/prometheus_metrics.js
@@ -7,9 +7,9 @@ This Source Code Form is subject to the terms of the Mozilla Public License, v. 
 
 This Source Code Form is “Incompatible With Secondary Licenses”, as defined by the Mozilla Public License, v. 2.0.
 */
-const prometheusMetricsHandler = (promClient) => (req, res) => {
-  res.set('Content-Type', promClient.register.contentType);
-  res.end(promClient.register.metrics());
+const prometheusMetricsHandler = (registry) => (req, res) => {
+  res.set('Content-Type', registry.contentType);
+  res.end(registry.metrics());
 };
 
 export default prometheusMetricsHandler;


### PR DESCRIPTION
Adds metrics for Prometheus bundling for the Hermes worker.

`hermes_bundle_uploads_total` as a counter to track successful uploads.

`hermes_bundle_upload_failures_total` as a counter to track failed
uploads.