### PR TITLE
Change string logs to JSON logs

### DIFF
--- a/src/migrations/Migrator.js
+++ b/src/migrations/Migrator.js
@@ -43,12 +43,12 @@ class Migrator {
     const version = this.getVersionFromPath(fullPath);
     const getCurrentVersion = await this.getCurrentVersion();
     if (version > getCurrentVersion) {
-      logger.info(`Migrating: ${path.basename(fullPath)}`);
+      logger.info({message: `Migrating: ${path.basename(fullPath)}`});
       const imported = require(fullPath);
       await imported.up(this.db, this.config, logger);
       await this.db.collection('migrations').findOneAndReplace({}, {version});
     } else {
-      logger.info(`Ignoring migration: ${path.basename(fullPath)}`);
+      logger.info({message: `Ignoring migration: ${path.basename(fullPath)}`});
     }
   }
 
@@ -63,7 +63,9 @@ class Migrator {
         return;
       }
 
-      logger.info('Another migration is running. Waiting for it to end.');
+      logger.info({
+        message: 'Another migration is running. Waiting for it to end.'
+      });
       await this.sleepFunction(this.config.migrationSleepTimeInSeconds);
     }
   }

--- a/src/start_hermes.js
+++ b/src/start_hermes.js
@@ -20,7 +20,9 @@ async function start(logger) {
   if (await builder.migrator.isMigrationNecessary()) {
     throw new Error('Migration needs to be done');
   }
-  await waitForChainSync(builder.web3, 5, () => logger.info('Ethereum client is not in sync. Retrying in 5 seconds'));
+  await waitForChainSync(builder.web3, 5, () => logger.info({
+    message: 'Ethereum client is not in sync. Retrying in 5 seconds'
+  }));
   await builder.ensureAccountIsOnboarded([Role.HERMES]);
   const strategy = loadStrategy(config.uploadStrategy);
   const worker = new HermesWorker(

--- a/src/start_server.js
+++ b/src/start_server.js
@@ -21,7 +21,9 @@ async function start(logger) {
     throw new Error('Migration needs to be done');
   }
   await builder.ensureAdminAccountExist();
-  await waitForChainSync(builder.web3, 5, () => logger.info('Ethereum client is not in sync. Retrying in 5 seconds'));
+  await waitForChainSync(builder.web3, 5, () => logger.info({
+    message: 'Ethereum client is not in sync. Retrying in 5 seconds'
+  }));
   const role = await builder.ensureAccountIsOnboarded([Role.ATLAS, Role.HERMES]);
   const worker = new ServerWorker(
     builder.dataModelEngine,

--- a/src/workers/server_worker.js
+++ b/src/workers/server_worker.js
@@ -38,7 +38,7 @@ export default class ServerWorker extends Worker {
   }
 
   async work() {
-    this.logger.info('starting server');
+    this.logger.info({message: 'Starting server'});
 
     const registry = new promClient.Registry();
     this.collectMetricsInterval = promClient.collectDefaultMetrics({


### PR DESCRIPTION
Most logs are written in JSON. Plain string logs are inconsistent with
the format Morgan uses. Emit JSON so that logging services can easily
parse the logs.