### PR TITLE
Remove pin packages in Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
   - npx yarn dev:lint
   - export MONGO_HOSTS="localhost:27017" MONGO_DB_NAME="ambrosus" && npx yarn migrate
   - npx yarn test
-  - docker run --rm -i hadolint/hadolint < Dockerfile
+  - docker run --rm -i hadolint/hadolint hadolint --ignore DL3018 - < Dockerfile
 
 notifications:
   slack:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:10-alpine
 
-RUN apk add git=~2.20 python=~2.7 make=~4.2 g++=~8.3 --no-cache
+RUN apk add git python make g++ --no-cache
 
 WORKDIR /app
 


### PR DESCRIPTION
This practice is incorrect. Is it necessary to pin packages that important 
for build process. Alpine as any other distribution update packages and 
Dockerfile with pinned app will fail.

# Checklist:

- [x] Code follows the style guidelines
- [x] Documentation updated
- [x] Corner cases evaluated and handled
- [x] Automatic tests added/update
- [x] Automatic tests pass
- [x] Software runs (locally or hosted)
- [x] Sanity check passed
- [x] Self-review passed