### PR TITLE
Fix HermesBackupWorker intervals

### DIFF
--- a/src/start_hermes.js
+++ b/src/start_hermes.js
@@ -69,7 +69,7 @@ async function start(logger) {
     hermesBackup,
     builder.workerTaskTrackingRepository,
     logger,
-    config.HermesBackupWorkerInterval
+    config.hermesBackupWorkerInterval
   );
 
   setTimeout(async () => {


### PR DESCRIPTION
## Why
Typo in field name led to incorrect work of HermesBackupWorker. WorkInterval was undefined and backup was executed only once with initialization of HermesBackupWorker, because timeLeft in PeriodicWorker was equal NaN.

## What
- Write field name correctly 

# Checklist:

- [ ] Code follows the style guidelines
- [ ] Documentation updated
- [ ] Corner cases evaluated and handled
- [ ] Automatic tests added/update
- [ ] Automatic tests pass
- [ ] Software runs (locally or hosted)
- [ ] Sanity check passed
- [ ] Self-review passed
