### PR TITLE
Fix typo in class name

### DIFF
--- a/src/workers/atlas_resolvers/atlas_transfer_resolver.js
+++ b/src/workers/atlas_resolvers/atlas_transfer_resolver.js
@@ -11,7 +11,7 @@ import promClient from 'prom-client';
 import BundleShelteringResolver from './bundle_sheltering_resolver';
 import {atlasResolutionStatus} from './atlas_resolver';
 
-export default class AtlaTransferResolver extends BundleShelteringResolver {
+export default class AtlasTransferResolver extends BundleShelteringResolver {
   constructor(
     web3,
     dataModelEngine,


### PR DESCRIPTION
## Why
There was a typo in class name, but due to default export everything worked correctly

## What was done
Typo was fixed

# Checklist:

- [ ] Code follows the style guidelines
- [ ] Documentation updated
- [ ] Corner cases evaluated and handled
- [ ] Automatic tests added/update
- [ ] Automatic tests pass
- [ ] Software runs (locally or hosted)
- [ ] Sanity check passed
- [ ] Self-review passed
